### PR TITLE
Add identity utilities and user API

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,21 +4,35 @@ import { webcrypto } from 'crypto';
 
 // Mock IndexedDB for testing
 const mockIndexedDB = {
-  open: jest.fn(() => ({
-    result: {
-      transaction: jest.fn(() => ({
-        objectStore: jest.fn(() => ({
-          put: jest.fn(),
-          get: jest.fn(),
-          clear: jest.fn(),
+  open: jest.fn(() => {
+    const request = {
+      result: {
+        transaction: jest.fn(() => ({
+          objectStore: jest.fn(() => ({
+            put: jest.fn(() => ({ onsuccess: null, onerror: null })),
+            get: jest.fn(() => ({
+              onsuccess: null,
+              onerror: null,
+              result: undefined,
+            })),
+            clear: jest.fn(() => ({ onsuccess: null, onerror: null })),
+          })),
         })),
-      })),
-      createObjectStore: jest.fn(),
-    },
-    onsuccess: null,
-    onerror: null,
-    onupgradeneeded: null,
-  })),
+        createObjectStore: jest.fn(),
+      },
+      onsuccess: null,
+      onerror: null,
+      onupgradeneeded: null,
+    };
+
+    setTimeout(() => {
+      if (request.onsuccess) {
+        request.onsuccess({ target: request });
+      }
+    }, 0);
+
+    return request;
+  }),
 };
 
 Object.defineProperty(window, 'indexedDB', {

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { verifySessionCookie } from '@/lib/crypto';
-import { Session } from '@/lib/models';
+import { Session, User } from '@/lib/models';
 import { connectToDatabase } from '@/lib/mongodb';
 
 export async function GET(request: NextRequest) {
@@ -45,9 +45,14 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Session expired' }, { status: 401 });
     }
 
+    const user = await User.findOne({ deviceId: session.deviceId._id });
+
     return NextResponse.json({
       authenticated: true,
       deviceId: session.deviceId._id.toString(),
+      user: user
+        ? { publicId: user.publicId, displayName: user.displayName }
+        : null,
       sessionInfo: {
         createdAt: session.createdAt,
         expiresAt: session.expiresAt,

--- a/src/app/api/user/upsert/route.ts
+++ b/src/app/api/user/upsert/route.ts
@@ -1,0 +1,84 @@
+import mongoose from 'mongoose';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { verifySessionCookie } from '@/lib/crypto';
+import { Session, User } from '@/lib/models';
+import { connectToDatabase } from '@/lib/mongodb';
+
+const schema = z.object({
+  deviceId: z.string().refine((id) => mongoose.Types.ObjectId.isValid(id)),
+  publicId: z.string(),
+  displayName: z.string(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    await connectToDatabase();
+    const sessionSecret = process.env.SESSION_SECRET;
+    if (!sessionSecret) {
+      throw new Error('SESSION_SECRET environment variable is not set');
+    }
+
+    const signedCookie = request.cookies.get('sid')?.value;
+    if (!signedCookie) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const sessionId = await verifySessionCookie(signedCookie, sessionSecret);
+    if (!sessionId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const session = await Session.findById(sessionId);
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { deviceId, publicId, displayName } = schema.parse(body);
+
+    let attempt = 0;
+    let finalName = displayName;
+    while (attempt < 3) {
+      try {
+        const user = await User.findOneAndUpdate(
+          { deviceId },
+          { deviceId, publicId, displayName: finalName },
+          { upsert: true, new: true, setDefaultsOnInsert: true },
+        );
+        return NextResponse.json({
+          ok: true,
+          user: { publicId: user.publicId, displayName: user.displayName },
+        });
+      } catch (err) {
+        const mongoErr = err as {
+          code?: number;
+          keyPattern?: Record<string, unknown>;
+        };
+        if (mongoErr.code === 11000 && mongoErr.keyPattern?.displayName) {
+          finalName = `${displayName}-${(attempt + 1).toString()}`;
+          attempt += 1;
+        } else {
+          console.error('User upsert error:', err);
+          return NextResponse.json(
+            { error: 'Internal server error' },
+            { status: 500 },
+          );
+        }
+      }
+    }
+
+    return NextResponse.json({ conflict: true }, { status: 409 });
+  } catch (error) {
+    console.error('User upsert error:', error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Invalid request data', details: error.errors },
+        { status: 400 },
+      );
+    }
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,32 @@
+export const metadata = { title: 'Home - Rodeo Companion' } as const;
+
+export default function Page() {
+  return (
+    <section className="grid grid-cols-2 gap-4 p-4 text-center">
+      <a
+        href="/scores"
+        className="rounded-lg border p-8 font-semibold hover:bg-gray-50"
+      >
+        Scores
+      </a>
+      <a
+        href="/schedule"
+        className="rounded-lg border p-8 font-semibold hover:bg-gray-50"
+      >
+        Schedule
+      </a>
+      <a
+        href="/competitors"
+        className="rounded-lg border p-8 font-semibold hover:bg-gray-50"
+      >
+        Competitors
+      </a>
+      <a
+        href="/shop"
+        className="rounded-lg border p-8 font-semibold hover:bg-gray-50"
+      >
+        Shop
+      </a>
+    </section>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,15 @@ export const metadata = { title: 'Rodeo Companion' };
 
 export default function Home() {
   return (
-    <section className="p-4">
-      <h1 className="text-2xl font-bold">Live Now</h1>
-      <p>Welcome to the Rodeo Companion App.</p>
+    <section className="space-y-4 p-4 text-center">
+      <h1 className="text-2xl font-bold">Welcome to Rodeo</h1>
+      <p className="text-sm">Secure device-based authentication</p>
+      <a
+        href="/home"
+        className="mt-4 inline-block rounded-md bg-blue-600 px-6 py-3 text-white"
+      >
+        Sign in with this device
+      </a>
     </section>
   );
 }

--- a/src/lib/identity.test.ts
+++ b/src/lib/identity.test.ts
@@ -1,0 +1,21 @@
+import { formatPublicId, makeDisplayName } from './identity';
+import adjectives from './wordlists/genz_adjectives';
+import nouns from './wordlists/genz_nouns';
+
+describe('identity helpers', () => {
+  it('formats public id without vowels', () => {
+    const hash = new Uint8Array(32);
+    for (let i = 0; i < hash.length; i++) hash[i] = i;
+    const id = formatPublicId(hash);
+    expect(id.startsWith('RDO-')).toBe(true);
+    expect(id.length).toBe(14);
+    expect(id).not.toMatch(/[AEIOU]/);
+  });
+
+  it('generates deterministic display name', () => {
+    const hash = new Uint8Array([1, 2]);
+    const name = makeDisplayName(hash);
+    const expected = `${adjectives[1 % adjectives.length]}-${nouns[2 % nouns.length]}`;
+    expect(name).toBe(expected);
+  });
+});

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -1,0 +1,34 @@
+import adjectives from './wordlists/genz_adjectives';
+import nouns from './wordlists/genz_nouns';
+
+function base32NoPadding(bytes: Uint8Array): string {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  let bits = 0;
+  let value = 0;
+  let output = '';
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += alphabet[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += alphabet[(value << (5 - bits)) & 31];
+  }
+  return output;
+}
+
+export function formatPublicId(hash: Uint8Array): string {
+  const raw = base32NoPadding(hash.slice(0, 10)).toUpperCase();
+  const filtered = raw.replace(/[AEIOU]/g, '');
+  const code = filtered.slice(0, 9).padEnd(9, 'X');
+  return `RDO-${code.slice(0, 5)}-${code.slice(5)}`;
+}
+
+export function makeDisplayName(hash: Uint8Array, offset = 0): string {
+  const idxA = hash[offset % hash.length] % adjectives.length;
+  const idxB = hash[(offset + 1) % hash.length] % nouns.length;
+  return `${adjectives[idxA]}-${nouns[idxB]}`;
+}

--- a/src/lib/models/Device.ts
+++ b/src/lib/models/Device.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema, Document } from 'mongoose';
+import mongoose, { Document, Schema } from 'mongoose';
 
 export interface IDevice extends Document {
   _id: mongoose.Types.ObjectId;
@@ -21,8 +21,6 @@ const DeviceSchema = new Schema<IDevice>({
   publicKeyThumbprint: {
     type: String,
     required: true,
-    unique: true,
-    index: true,
   },
   createdAt: {
     type: Date,
@@ -60,4 +58,5 @@ const DeviceSchema = new Schema<IDevice>({
 DeviceSchema.index({ status: 1 });
 DeviceSchema.index({ publicKeyThumbprint: 1 }, { unique: true });
 
-export const Device = mongoose.models.Device || mongoose.model<IDevice>('Device', DeviceSchema);
+export const Device =
+  mongoose.models.Device || mongoose.model<IDevice>('Device', DeviceSchema);

--- a/src/lib/models/User.ts
+++ b/src/lib/models/User.ts
@@ -1,0 +1,30 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface IUser extends Document {
+  deviceId: mongoose.Types.ObjectId;
+  publicId: string;
+  displayName: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const UserSchema = new Schema<IUser>(
+  {
+    deviceId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Device',
+      required: true,
+      index: true,
+    },
+    publicId: { type: String, required: true, unique: true },
+    displayName: { type: String, required: true, unique: true },
+  },
+  { timestamps: true },
+);
+
+UserSchema.index({ publicId: 1 }, { unique: true });
+UserSchema.index({ displayName: 1 }, { unique: true });
+UserSchema.index({ deviceId: 1 });
+
+export const User =
+  mongoose.models.User || mongoose.model<IUser>('User', UserSchema);

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -1,3 +1,4 @@
-export { Device, type IDevice } from './Device';
-export { Session, type ISession } from './Session';
 export { Challenge, type IChallenge } from './Challenge';
+export { Device, type IDevice } from './Device';
+export { type ISession, Session } from './Session';
+export { type IUser, User } from './User';

--- a/src/lib/wordlists/genz_adjectives.ts
+++ b/src/lib/wordlists/genz_adjectives.ts
@@ -1,0 +1,14 @@
+const adjectives = [
+  'neon',
+  'drip',
+  'rizz',
+  'gigachad',
+  'based',
+  'sigma',
+  'lowkey',
+  'goated',
+  'vibe',
+  'aura',
+];
+
+export default adjectives;

--- a/src/lib/wordlists/genz_nouns.ts
+++ b/src/lib/wordlists/genz_nouns.ts
@@ -1,0 +1,14 @@
+const nouns = [
+  'wolf',
+  'ninja',
+  'slay',
+  'glitch',
+  'phantom',
+  'vortex',
+  'meme',
+  'pixel',
+  'rhino',
+  'titan',
+];
+
+export default nouns;


### PR DESCRIPTION
## Summary
- add Gen-Z wordlists and identity helpers for public IDs and display names
- create User model and upsert API route
- extend `/api/me` to return user info
- add simple Home page with four buttons
- update landing page text
- tweak Jest setup for IndexedDB mocking

## Testing
- `npm test -- -w=1` *(fails: Cannot set properties of undefined in keyManager tests)*

------
https://chatgpt.com/codex/tasks/task_e_6885d317538c832abb45b97c764c3094