### PR TITLE
Fix mobile nav and auto-refresh after signup

### DIFF
--- a/src/components/auth/AuthButton.tsx
+++ b/src/components/auth/AuthButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
 
 import { authenticateDevice } from '@/lib/client/auth';
@@ -8,6 +9,7 @@ import { useAuth } from './AuthProvider';
 
 export function AuthButton() {
   const { authenticated, refresh } = useAuth();
+  const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,7 +24,7 @@ export function AuthButton() {
         setError(result.error);
       } else {
         await refresh(); // Refresh auth state
-        window.location.reload();
+        router.push('/home');
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Authentication failed');

--- a/src/components/auth/AuthButton.tsx
+++ b/src/components/auth/AuthButton.tsx
@@ -22,6 +22,7 @@ export function AuthButton() {
         setError(result.error);
       } else {
         await refresh(); // Refresh auth state
+        window.location.reload();
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Authentication failed');

--- a/src/components/nav/BottomTabs.tsx
+++ b/src/components/nav/BottomTabs.tsx
@@ -19,10 +19,10 @@ export default function BottomTabs() {
 
   return (
     <nav
-      className="fixed bottom-0 left-0 right-0 border-t bg-white sm:hidden dark:bg-black"
+      className="fixed bottom-0 left-0 right-0 overflow-x-auto border-t bg-white sm:hidden dark:bg-black"
       aria-label="Bottom navigation"
     >
-      <ul className="flex justify-around">
+      <ul className="flex flex-nowrap justify-around whitespace-nowrap">
         {tabs.map((tab) => (
           <li key={tab.href}>
             <Link


### PR DESCRIPTION
## Summary
- auto-reload the page after successful authentication so sign-up completes without manual refresh
- make the mobile bottom navigation horizontally scrollable so Settings and other tabs are reachable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68861e6b0edc832a88bfbd5a6a00ca67